### PR TITLE
Add circleci config

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,0 +1,117 @@
+# Javascript Node CircleCI 2.0 configuration file
+#
+# Check https://circleci.com/docs/2.0/language-javascript/ for more details
+#
+version: 2
+jobs:
+  build:
+    docker:
+      - image: circleci/node:8.14.1
+
+    working_directory: ~/repo
+
+    steps:
+      - checkout
+
+      - restore_cache:
+          keys:
+            - v1-dependencies-{{ checksum "package.json" }}
+            - v1-dependencies-
+
+      - run: npm install
+      - run: cd functions && npm install
+      - run:
+          name: Build
+          command: |
+              if [ $CIRCLE_BRANCH = 'master' ]; then
+                npm run build:production
+              fi
+              if [ $CIRCLE_BRANCH = 'staging' ]; then
+                npm run build:staging
+              fi
+              if [ $CIRCLE_BRANCH = 'develop' ]; then
+                npm run build:development
+              fi
+
+      - save_cache:
+          paths:
+            - node_modules
+          key: v1-dependencies-{{ checksum "package.json" }}
+
+      - persist_to_workspace:
+          root: /home/circleci/repo
+          paths:
+            - .
+
+  deploy-dev:
+    docker:
+      - image: circleci/node:8.14.1
+    working_directory: ~/repo
+    steps:
+      - attach_workspace:
+          at: ~/repo
+      - run:
+          name: Firebase use
+          command: ./node_modules/.bin/firebase use develop --token=$FIREBASE_DEPLOY_TOKEN
+      - run:
+          name: Firebase deploy
+          command: ./node_modules/.bin/firebase deploy --only hosting,functions --token=$FIREBASE_DEPLOY_TOKEN
+
+  deploy-staging:
+    docker:
+      - image: circleci/node:8.14.1
+    working_directory: ~/repo
+    steps:
+      - attach_workspace:
+          at: ~/repo
+      - run:
+          name: Firebase use
+          command: ./node_modules/.bin/firebase use staging --token=$FIREBASE_DEPLOY_TOKEN
+      - run:
+          name: Firebase deploy
+          command: ./node_modules/.bin/firebase deploy --only hosting,functions --token=$FIREBASE_DEPLOY_TOKEN
+
+  deploy-production:
+    docker:
+      - image: circleci/node:8.14.1
+    working_directory: ~/repo
+    steps:
+      - attach_workspace:
+          at: ~/repo
+      - run:
+          name: Firebase use
+          command: ./node_modules/.bin/firebase use production --token=$FIREBASE_DEPLOY_TOKEN
+      - run:
+          name: Firebase deploy
+          command: ./node_modules/.bin/firebase deploy --only hosting,functions --token=$FIREBASE_DEPLOY_TOKEN
+
+workflows:
+  version: 2
+  build-deploy:
+    jobs:
+      - build:
+          filters:
+            branches:
+              only:
+                - develop
+                - staging
+                - master
+
+      - deploy-dev:
+          requires:
+            - build
+          filters:
+            branches:
+              only: develop
+      - deploy-staging:
+          requires:
+            - build
+          filters:
+            branches:
+              only: staging
+      - deploy-production:
+          requires:
+            - build
+          filters:
+            branches:
+              only: master


### PR DESCRIPTION
I think it would be good to support multiple CI/CD solutions. What if we pick one to be the default (CircleCI?) and then maintain 1 or more branches to support other services.

AWS CodeBuild/CodePipeline is the only other option on my list atm.